### PR TITLE
feat: Kafka, Zookeeper, Redis 설정 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,8 @@ services:
       KAFKA_LISTENERS: INTERNAL://0.0.0.0:29092,EXTERNAL://0.0.0.0:9092
       
       # Spring Boot 등 호스트 앱은 localhost:9092로, 컨테이너끼리는 kafka:29092로 통신
-      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka:29092,EXTERNAL://localhost:9092
-      
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka:29092,EXTERNAL://${KAFKA_EXTERNAL_HOST:-localhost}:9092
+
       # 브로커 간 내부 통신용 리스너 지정
       KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
       


### PR DESCRIPTION
- Kafka 서비스 도커 컨테이너 설정 추가
- Zookeeper 서비스 및 Kafka 의존성 설정 추가
- Redis 서비스 도커 컨테이너 설정 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 로컬 개발용 Docker Compose 추가: Zookeeper, Kafka, Redis로 구성된 개발 스택을 간편히 실행할 수 있습니다.
  * Kafka에 내부/외부 리스너 분리 설정이 포함되어 네트워크 경로 구성이 명확해졌습니다(개발용 포트 노출 포함).
  * Redis는 디스크 영속성(RDB/AOF)을 비활성화하여 개발 환경에서 경량화되고 빠르게 재시작됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->